### PR TITLE
Add one-shot timer for crosswalk stop

### DIFF
--- a/publisher/crosswalk_detector_node.py
+++ b/publisher/crosswalk_detector_node.py
@@ -1,7 +1,6 @@
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Bool
-import time
 
 class CrosswalkDetectorNode(Node):
     def __init__(self):
@@ -11,11 +10,26 @@ class CrosswalkDetectorNode(Node):
             Bool,
             '/camera/trigger_crosswalk',
             self.trigger_callback,
+            10,
+        )
+
+        # Publisher used to command the vehicle to stop when a crosswalk is
+        # detected.
+        self.stop_publisher = self.create_publisher(
+            Bool,
+            '/crosswalk/stop_signal',
             10
         )
 
-        self.publisher = self.create_publisher(Bool, '/crosswalk/stop_signal', 10)
+        # Publisher that notifies the motor controller to start moving again
+        # once the stop period has elapsed.
+        self.start_publisher = self.create_publisher(
+            Bool,
+            '/motor_controller/start_signal',
+            10,
+        )
         self.timer_running = False
+        self.stop_timer = None
         self.get_logger().info("CrosswalkDetectorNode is ready.")
 
     def trigger_callback(self, msg):
@@ -23,15 +37,23 @@ class CrosswalkDetectorNode(Node):
             self.get_logger().info('Trigger received: stopping vehicle for 5 seconds.')
             self.publish_stop_signal(True)
             self.timer_running = True
-            self.create_timer(5.0, self.end_stop_signal)
+            self.stop_timer = self.create_timer(5.0, self.end_stop_signal)
 
     def publish_stop_signal(self, state: bool):
         msg = Bool()
         msg.data = state
-        self.publisher.publish(msg)
+        self.stop_publisher.publish(msg)
 
     def end_stop_signal(self):
         self.publish_stop_signal(False)
+        # Stop the timer so it does not repeatedly fire.
+        if self.stop_timer is not None:
+            self.stop_timer.cancel()
+            self.stop_timer = None
+        # Notify the motor controller that it can resume movement.
+        start_msg = Bool()
+        start_msg.data = True
+        self.start_publisher.publish(start_msg)
         self.get_logger().info('Stop complete: resuming movement.')
         self.timer_running = False
 


### PR DESCRIPTION
## Summary
- fix crosswalk stop timer to fire once
- cancel timer and send start signal after stop

## Testing
- `python -m py_compile publisher/crosswalk_detector_node.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874da8f4a54832399afa7d8eaaae850